### PR TITLE
Added toString() on README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ $ npm i await-spawn -S
 const spawn = require('await-spawn')
 
 const main = async () => {
-  const bl = await spawn('ls', [ '-al' ])
+    try {
+        const bl = await spawn('ls', [ '-al' ])
+    } catch (e) {
+        console.log(e.stderr.toString());
+    }
   console.log(bl.toString())
 }
 


### PR DESCRIPTION
Added toString() for better clarity.

It's not quite obvious, since promises using await tend to return Strings and catched easily, BufferList was mentioned but it wasn't somehow highlighted given the importance of ability to catch error output from child!