### PR TITLE
Make stdout available when the command fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = (...args) => {
         const err = new Error(`child exited with code ${code}`)
         err.code = code
         err.stderr = stderr
+        err.stdout = stdout
         reject(err)
       }
     })

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ test('failed command throws error with code', async t => {
   } catch (err) {
     t.equal(err.message, 'child exited with code 1')
     t.ok(err.stderr, '.stderr is set')
+    t.ok(err.stdout, '.stdout is set')
     t.is(err.stderr.length, 0, 'BufferList has 0 length in this case')
     t.end()
   }


### PR DESCRIPTION
It's common for commands to send output to stdout before sending anything to stderr upon failure (and some commands mistakenly send errors to stdout). This ensures that the caller can access both streams if a command fails.