### PR TITLE
use close event instead exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = (...args) => {
   const promise = new Promise((resolve, reject) => {
     child.on('error', reject)
 
-    child.on('exit', code => {
+    child.on('close', code => {
       if (code === 0) {
         resolve(stdout)
       } else {


### PR DESCRIPTION
I receive unpredictable case with empty buffer. 
It happens because `exit` called very soon.

> When the 'exit' event is triggered, child process stdio streams might still be open.

https://nodejs.org/dist/latest-v14.x/docs/api/child_process.html#child_process_event_exit

Seems listen `close` event is better